### PR TITLE
Small corrections

### DIFF
--- a/courses/01_beginners/main.tex
+++ b/courses/01_beginners/main.tex
@@ -235,7 +235,7 @@ This course is intended for beginners in Kokkos and performance portability with
     \small
     \begin{itemize}
         \item CPUs are designed for general purpose, from sequential task to parallel computing. They run the operating system as well.
-        \item tens to hundred of cores in biggest processors
+        \item Tens to hundred of cores in biggest processors
         \item SIMD (Single Instruction Multiple Data) units for accelerating arithmetic operations
     \end{itemize}
     
@@ -254,7 +254,7 @@ This course is intended for beginners in Kokkos and performance portability with
 \small
 \begin{itemize}
     \item GPUs are designed to achieve massive parallelism of simple kernels
-    \item hundreds of computing units, thousands of threads
+    \item Hundreds of computing units, thousands of threads
     \item Large SIMT vector unit (Single Instruction Multiple Threads) per computing unit
 \end{itemize}
 
@@ -374,7 +374,7 @@ Probably yes if you:
 
 Maybe not if:
 \begin{itemize}
-    \item Need to tune your algorithms to work the fast as possible on a given hardware
+    \item Need to tune your algorithms to work as fast as possible on a given hardware
 \end{itemize}
 
 \end{frame}
@@ -506,7 +506,7 @@ Maybe not if:
     \begin{itemize}
         \item Kokkos is compiled to target a specific backend
         \item Only one CPU backend and one GPU backend maximum can be compiled at a time
-        \item Kokkos is portable until you compile it. You need a compilation per backend.
+        \item Kokkos is portable until you compile it. You need one compilation per backend.
     \end{itemize}
 
     \hspace{1cm}
@@ -638,7 +638,7 @@ cmake ${srcdir} -DCMAKE_INSTALL_PREFIX=${kokkos_install_folder} \
 % _____________________________________________________________________________
 
 \begin{frame}[fragile]
-    \frametitle{start a Kokkos program} 
+    \frametitle{Start a Kokkos program}
     \begin{itemize}
         \item Include the Kokkos header file (like any other library)
         \item Use the Kokkos namespace \texttt{Kokkos::}
@@ -1052,7 +1052,7 @@ Kokkos::View<int**>::HostMirror host_matrix =
     \frametitle{Views and mirror Views in the host memory space}
 
 \begin{itemize}
-\item For portability reason, we use the mirror view whatever we compile with a CPU or GPU backend
+\item For portability reason, we use the mirror view whether we compile with a CPU or GPU backend
 \item With a CPU backend only, the mirror view lives in the same memory space as the original view
 \item \textbf{Problem:} the \texttt{create\_mirror} function always create a view with allocated memory (memory duplication)
 \end{itemize}
@@ -1086,7 +1086,7 @@ Kokkos::View<int**>::HostMirror host_matrix =
     \frametitle{Deep copy function to exchange data between memory spaces}
 
 \begin{itemize}
-    \item Kokkos provides a function \texttt{deep\_copy} to copy data between views of different memory spaces
+    \item Kokkos provides a function \texttt{deep\_copy} to copy data between views in different memory spaces
     \item Views must have the same layout and extent
     \item The function is used to copy data from the source view to the destination view
 \end{itemize}
@@ -1267,7 +1267,7 @@ KOKKOS_LAMBDA(int i) {
 % _____________________________________________________________________________
 
 \begin{frame}[fragile]
-    \frametitle{Where my parallel loop is executed?} 
+    \frametitle{Where is my parallel loop executed?}
 
 \begin{itemize}
     \item Where the loop is executed is called the \textcolor{orange}{\textbf{execution space}}
@@ -1544,7 +1544,9 @@ Kokkos::parallel_for("my_loop",
 
 \footnotesize
 \begin{minted}{C++}
-double result = 0.0;
+// No need to initialize the variable, it will be
+// done by the parallel_reduce call
+double result;
 
 Kokkos::parallel_reduce("my_reduction", N,
 KOKKOS_LAMBDA(int i, double& local_result) {
@@ -1565,12 +1567,12 @@ KOKKOS_LAMBDA(int i, double& local_result) {
     \item Kokkos provides reducers (\texttt{Reducer\_op}) for the most common operations:
     \begin{itemize}
         \item \texttt{Kokkos::Sum}: Sum of the elements
-        \item \texttt{Kokkos::Max}: and \texttt{Kokkos::Min}: Maximum and minimum of the elements
+        \item \texttt{Kokkos::Max}: and \texttt{Kokkos::Min}: Maximum and minimum element
         \item \texttt{Kokkos::Prod}: Product of the elements
-        \item \texttt{Kokkos::MaxLoc} and \texttt{Kokkos::MinLoc}: Maximum and minimum of the elements with the index
+        \item \texttt{Kokkos::MaxLoc} and \texttt{Kokkos::MinLoc}: Maximum and minimum element with their index
         \item and mores
     \end{itemize}  
-    \item You can also create your own reducer but not the subject of this introduction
+    \item You can also create your own reducer but this is not the subject of this introduction
 \end{itemize}
 
 \begin{block}{}
@@ -1588,9 +1590,9 @@ Sum of an array using a parallel reduction:
 
 \footnotesize
 \begin{minted}{C++}
-double result = 0.0;
-Kokkos::view<double*> A("A", N);
-
+double result;
+Kokkos::View<double*> A("A", N);
+// ... Fill vector A with data ...
 Kokkos::parallel_reduce("my_reduction", N,
 KOKKOS_LAMBDA(int i, double& local_result) {
     local_result += A(i);
@@ -1619,10 +1621,10 @@ Max of an array using a parallel reduction:
 
 \footnotesize
 \begin{minted}{C++}
-double max_value = -1.0;
+double max_value;
 
-Kokkos::view<double*> A("A", N);
-
+Kokkos::View<double*> A("A", N);
+// ... Fill vector A with data ...
 Kokkos::parallel_reduce("my_reduction", N,
 KOKKOS_LAMBDA(int i, double& local_max_value) {
     if (A(i) > local_max_value) {
@@ -1642,9 +1644,8 @@ Min and index of an array using a parallel reduction:
 
 \footnotesize
 \begin{minted}{C++}
-double min_value = 1.0e10;
-int min_index = -1;
-Kokkos::view<double*> A("A", N);
+Kokkos::View<double*> A("A", N);
+// ... Fill vector A with data ...
 
 // Use a structure containing val and loc variables
 typedef Kokkos::MinLoc<double,int>::value_type minloc_type;
@@ -1652,8 +1653,8 @@ minloc_type minloc;
 
 Kokkos::parallel_reduce( "MinLocReduce", N,
 KOKKOS_LAMBDA (int i, minloc_type& lminloc) {
-    if( A(i) < lminloc.val ) { 
-        lminloc.val = val;
+    if( A(i) < lminloc.val ) {
+        lminloc.val = A(i);
         lminloc.loc = i;
     }
 }, Kokkos::MinLoc<double,int>(minloc));

--- a/exercises/02_first_program/README.md
+++ b/exercises/02_first_program/README.md
@@ -24,7 +24,7 @@ make
 
 - Run the program and check the output.
 
-For instance if you have an Apple computer and you are using the Clang compiler, you should something like this:
+For instance if you have an Apple computer and you are using the Clang compiler, you should get something like this:
 
 ```bash
   Kokkos Version: 4.4.0

--- a/exercises/03_basic_view/main.cpp
+++ b/exercises/03_basic_view/main.cpp
@@ -10,7 +10,7 @@ int main(int argc, char* argv[]) {
         int Ny = 15;
         int Nz = 20;
 
-        // Read Nx, Ny, Nz from command line
+        // Read Nx, Ny, Nz from the command line
         if (argc == 4) {
             Nx = std::atoi(argv[1]);
             Ny = std::atoi(argv[2]);

--- a/exercises/03_basic_view/solution/main.cpp
+++ b/exercises/03_basic_view/solution/main.cpp
@@ -10,7 +10,7 @@ int main(int argc, char* argv[]) {
         int Ny = 15;
         int Nz = 20;
 
-        // Read Nx, Ny, Nz from command line
+        // Read Nx, Ny, Nz from the command line
         if (argc == 4) {
             Nx = std::atoi(argv[1]);
             Ny = std::atoi(argv[2]);

--- a/exercises/04_deep_copy/README.md
+++ b/exercises/04_deep_copy/README.md
@@ -4,13 +4,13 @@
 
 In this exercise, you will learn how to create a mirror view and how to use the `Kokkos::deep_copy` function to copy data between different execution spaces.
 
-For this aim, we will create a mirror View of the existing View `matrix` and copy the data from the mirror View to the original View `matrix`.
+For this purpose, we will create a mirror View of the existing View `matrix` and copy the data from the mirror View to the original View `matrix`.
 Then, we will create a new mirror View `mirror_2` and copy the data from the original View `matrix` to the mirror View `mirror_2`.
 The goal here is to move the data from the host to the device and back to the host in `mirror_2`.
 Since at this stage, you do not know how to use the device, we use this second mirror View to ensure that the transfer were done correctly.
 For this, we will simply compare the content of the two mirror Views located on the Host.
 
-## Step 1: Create a a mirror view
+## Step 1: Create a mirror view
 
 We will start from the state of `main.cpp` of the previous exercise.
 
@@ -46,7 +46,7 @@ for (int i = 0; i < Nx; i++) {
 
 - Create a new mirror View called `mirror_2` using the `Kokkos::create_mirror` function.
 
-**Reminder:** `Kokkos::create_mirror` creates a mirror View with the same properties as the original View but on the host. Always duplicated the data.
+**Reminder:** `Kokkos::create_mirror` creates a mirror View with the same properties as the original View but on the host. Always duplicating the data.
 
 - Use the `Kokkos::deep_copy` function to copy the data from the original View `matrix` to the mirror View `mirror_2`.
 
@@ -73,14 +73,24 @@ for (int i = 0; i < Nx; i++) {
 ## step 6: Timers
 
 The goal of this step is to measure the time of the deep copy operations. For this aim, you can use the `Kokkos::Timer` class or the C++ way.
-The `Kokkos::Timer` class is very simple to use, see the example below:
+The `Kokkos::Timer` class is very simple to use, see the examples below:
 
 ```cpp
 Kokkos::Timer timer;
 // reset the timer
 timer.reset();
+// ... Code that needs to be timed ...
 // get the time in seconds since the last reset
 std::cout << "Time: " << timer.seconds() << std::endl;
+```
+Or
+```cpp
+Kokkos::Timer timer;
+double timer_start, timer_stop;
+timer_start = timer.seconds();
+// ... Code that needs to be timed ...
+timer_stop = timer.seconds();
+std::cout << "Time: " << timer_stop - timer_start << std::endl;
 ```
 
 - Measure the time of the first and second deep copy operations.
@@ -93,7 +103,7 @@ std::cout << "Time: " << timer.seconds() << std::endl;
 
 **What should I get:**
 
-If you are running the code using a CPU backend only, the View `matrix` is allocated on the Host. The mirror View `mirror` created with the `create_mirror_view` function is pointing toward the same data of `matrix`. However, the View `mirror_2` was created using the `create_mirror` function that implies a copy of the data from `matrix` to `mirror_2` (new allocation).
+If you are running the code using a CPU backend only, the View `matrix` is allocated on the Host. The mirror View `mirror` created with the `create_mirror_view` function is pointing toward the same data as `matrix`. However, the View `mirror_2` was created using the `create_mirror` function that implies a copy of the data from `matrix` to `mirror_2` (new allocation).
 The  first `deep_copy` do not perform any deep copy since the data is the same.
 The second `deep_copy` will however copy the data from `matrix` to `mirror_2`.
 Although the error between `mirror` and `mirror_2` should be zero, the first `deep_copy` timer should be very short and the second `deep_copy` timer significantly higher than the first one.

--- a/exercises/04_deep_copy/main.cpp
+++ b/exercises/04_deep_copy/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char* argv[]) {
         struct rusage usage;
 
         // _____________________________________________________
-        // Read Nx, Ny, Nz from command line
+        // Read Nx, Ny, Nz from the command line
         if (argc == 4) {
             Nx = std::atoi(argv[1]);
             Ny = std::atoi(argv[2]);
@@ -56,7 +56,7 @@ int main(int argc, char* argv[]) {
         std::cout << " - Matrix stride: " << stride[0] << " x " << stride[1] << " x " << stride[2] << std::endl;
 
         getrusage(RUSAGE_SELF, &usage);
-        std::cout << " - Memory usage: " << usage.ru_maxrss << " KB" << std::endl;
+        std::cout << "Total memory usage: " << usage.ru_maxrss << " KB" << std::endl;
 
         // _____________________________________________________
         // Create a mirror view of the matrix using create_mirror_view
@@ -64,7 +64,7 @@ int main(int argc, char* argv[]) {
         // ...
 
         // getrusage(RUSAGE_SELF, &usage);
-        // std::cout << "Memory usage: " << usage.ru_maxrss << " KB" << std::endl;
+        // std::cout << "Total memory usage: " << usage.ru_maxrss << " KB" << std::endl;
 
         // Initialize the matrix
 
@@ -86,7 +86,7 @@ int main(int argc, char* argv[]) {
         // ...
 
         // getrusage(RUSAGE_SELF, &usage);
-        // std::cout << "Memory usage: " << usage.ru_maxrss << " KB" << std::endl;
+        // std::cout << "Total memory usage: " << usage.ru_maxrss << " KB" << std::endl;
 
         // _____________________________________________________
         // Compare mirror and mirror_2

--- a/exercises/04_deep_copy/solution/main.cpp
+++ b/exercises/04_deep_copy/solution/main.cpp
@@ -19,7 +19,7 @@ int main(int argc, char* argv[]) {
         struct rusage usage;
 
         // _____________________________________________________
-        // Read Nx, Ny, Nz from command line
+        // Read Nx, Ny, Nz from the command line
         if (argc == 4) {
             Nx = std::atoi(argv[1]);
             Ny = std::atoi(argv[2]);
@@ -56,11 +56,12 @@ int main(int argc, char* argv[]) {
         std::cout << " - Matrix stride: " << stride[0] << " x " << stride[1] << " x " << stride[2] << std::endl;
 
         getrusage(RUSAGE_SELF, &usage);
-        std::cout << " - Memory usage: " << usage.ru_maxrss << " KB" << std::endl;
+        std::cout << "Total memory usage: " << usage.ru_maxrss << " KB" << std::endl;
 
         // _____________________________________________________
         // Create a mirror view of the matrix using create_mirror_view
 
+        std::cout << " 2) Creating the 3D view `mirror` with create_mirror_view()" << std::endl;
         Kokkos::View<double***>::HostMirror mirror = Kokkos::create_mirror_view(matrix);
 
         extent[0] = mirror.extent(0);
@@ -71,11 +72,11 @@ int main(int argc, char* argv[]) {
         stride[1] = mirror.stride(1);
         stride[2] = mirror.stride(2);
 
-        std::cout << "Mirror extent: " << extent[0] << " x " << extent[1] << " x " << extent[2] << std::endl;
-        std::cout << "Mirror stride: " << stride[0] << " x " << stride[1] << " x " << stride[2] << std::endl;
+        std::cout << " - Mirror extent: " << extent[0] << " x " << extent[1] << " x " << extent[2] << std::endl;
+        std::cout << " - Mirror stride: " << stride[0] << " x " << stride[1] << " x " << stride[2] << std::endl;
 
         getrusage(RUSAGE_SELF, &usage);
-        std::cout << "Memory usage: " << usage.ru_maxrss << " KB" << std::endl;
+        std::cout << "Total memory usage: " << usage.ru_maxrss << " KB" << std::endl;
 
         // Initialize the matrix
 
@@ -99,6 +100,7 @@ int main(int argc, char* argv[]) {
         // _____________________________________________________
         // New mirror view
 
+        std::cout << " 3) Creating the 3D view `mirror_2` with create_mirror()" << std::endl;
         Kokkos::View<double***>::HostMirror mirror_2 = Kokkos::create_mirror(matrix);
 
         // _____________________________________________________
@@ -111,7 +113,7 @@ int main(int argc, char* argv[]) {
         std::cout << "Time to deep copy matrix to mirror_2: " << timer_stop - timer_start << std::endl;
 
         getrusage(RUSAGE_SELF, &usage);
-        std::cout << "Memory usage: " << usage.ru_maxrss << " KB" << std::endl;
+        std::cout << "Total memory usage: " << usage.ru_maxrss << " KB" << std::endl;
 
         // _____________________________________________________
         // Compare mirror and mirror_2

--- a/exercises/05_parallel_loop/README.md
+++ b/exercises/05_parallel_loop/README.md
@@ -43,9 +43,9 @@ export OMP_PLACES=threads
 - Compile the program with the OpenMP backend and execute. Use large vector size for better results:
 
 ```bash
-./exe -N 10000000
+./exe 10000000
 ```
 
 - If you can access a GPU, compile and execute the program with the corresponding backend and execute the code.
 
-- Compare the timers between the two backends.
+- Compare the times between the two backends.

--- a/exercises/05_parallel_loop/main.cpp
+++ b/exercises/05_parallel_loop/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, char* argv[]) {
         double timer_stop  = 0;
 
         // _____________________________________________________
-        // Read Nx, Ny, Nz from command line
+        // Read Nx from the command line
 
         if (argc > 1) {
             N = std::atoi(argv[1]);

--- a/exercises/05_parallel_loop/solution/main.cpp
+++ b/exercises/05_parallel_loop/solution/main.cpp
@@ -16,7 +16,7 @@ int main(int argc, char* argv[]) {
         double timer_stop  = 0;
 
         // _____________________________________________________
-        // Read Nx, Ny, Nz from command line
+        // Read Nx from the command line
 
         if (argc > 1) {
             N = std::atoi(argv[1]);

--- a/exercises/06_parallel_reduce/README.md
+++ b/exercises/06_parallel_reduce/README.md
@@ -28,4 +28,4 @@ The goal of this exercise is to manipulate the Kokkos parallel reduction.
 ## *Optional* Step: timers
 
 - Add timers to measure the time spent to compute the sum and the max of the matrix.
-- Analyze the time spent on CPU and GPU for different LMatrix sizes.
+- Analyze the time spent on CPU and GPU for different Matrix sizes.

--- a/exercises/06_parallel_reduce/main.cpp
+++ b/exercises/06_parallel_reduce/main.cpp
@@ -13,9 +13,9 @@ int main(int argc, char* argv[]) {
         int Ny = 100;
 
         // _____________________________________________________
-        // Read Nx, Ny, Nz from command line
+        // Read Nx, Ny from the command line
 
-        if (argc > 1) {
+        if (argc >= 3) {
             Nx = std::atoi(argv[1]);
             Ny = std::atoi(argv[2]);
         }
@@ -39,18 +39,18 @@ int main(int argc, char* argv[]) {
 
         // ... Compute the sum of the matrix
 
-        // ... Print the result ...
-
         Kokkos::fence();
+
+        // ... Print the result ...
 
         // _____________________________________________________
         // Compute the maximum of the matrix
 
         // ... Compute the maximum of the matrix ...
 
-        // ... Print the result ...
-
         Kokkos::fence();
+
+        // ... Print the result ...
 
     }
     

--- a/exercises/06_parallel_reduce/solution/main.cpp
+++ b/exercises/06_parallel_reduce/solution/main.cpp
@@ -14,9 +14,9 @@ int main(int argc, char* argv[]) {
         Kokkos::Timer timer;
 
         // _____________________________________________________
-        // Read Nx, Ny, Nz from command line
+        // Read Nx, Ny from the command line
 
-        if (argc > 1) {
+        if (argc >= 3) {
             Nx = std::atoi(argv[1]);
             Ny = std::atoi(argv[2]);
         }
@@ -50,6 +50,8 @@ int main(int argc, char* argv[]) {
             lsum += matrix(i,j);
         }, sum);
 
+        Kokkos::fence();
+
         auto sum_stop = timer.seconds();
 
         std::cout << " Sum of the matrix: " << sum 
@@ -70,6 +72,8 @@ int main(int argc, char* argv[]) {
                 lmax = matrix(i,j);
             }
         }, Kokkos::Max<double>(max));
+
+        Kokkos::fence();
 
         auto max_stop = timer.seconds();
 


### PR DESCRIPTION
Small corrections of typos and small bugs in the slides

Still need to make some correction to the inkscape pictures :
page 59, 60, 61, 64: 
 - one '*' should be deleted in the mirror view declaration
 - the first parameter of the View device is missing (View name).

page 79:
change the title of the left column to "Kokkos compiled with a CPU backend only"
