### PR TITLE
Use branch restriction on CI

### DIFF
--- a/.github/workflows/courses.yml
+++ b/.github/workflows/courses.yml
@@ -6,29 +6,14 @@
 name: Generate courses PDF
 
 on:
-  push:
   pull_request:
     branches:
       - main
+    paths:
+      - 'courses/**'
 
 jobs:
-  changes:
-    runs-on: ubuntu-latest
-    outputs:
-      beginner_changed: ${{ steps.filter.outputs.beginner }}
-    steps:
-    - uses: actions/checkout@v4
-    - uses: dorny/paths-filter@v3
-      id: filter
-      with:
-        filters: |
-          beginner:
-            - 'courses/01_beginners/*.tex'
-            - 'images/**'
-
   build_beginner_course:
-    needs: changes
-    if: ${{ needs.changes.outputs.beginner_changed == 'true' }}
     runs-on: ubuntu-latest
     steps:
       - name: Set up Git repository
@@ -43,8 +28,3 @@ jobs:
           root_file: main.tex
           latexmk_shell_escape: true
           latexmk_use_xelatex: true
-      # - name: Upload PDF file
-      #   uses: actions/upload-artifact@v4
-      #   with:
-      #     name: beginner_pdf_course
-      #     path: courses/01_beginners/beginners.pdf

--- a/.github/workflows/projects.yml
+++ b/.github/workflows/projects.yml
@@ -8,32 +8,16 @@ name: Test projects
 run-name: Test projects
 
 on:
-  push:
-    paths:
-      - 'projects/**'
   pull_request:
     branches:
-      - '**'
+      - main
+    paths:
+      - 'projects/**'
 
 jobs:
 
-  # changes:
-  #   runs-on: ubuntu-latest
-  #   outputs:
-  #     projects_changed: ${{ steps.filter.outputs.wave }}
-  #   steps:
-  #   - uses: actions/checkout@v4
-  #   - uses: dorny/paths-filter@v3
-  #     id: filter
-  #     with:
-  #       filters: |
-  #         wave:
-  #           - 'projects/wave/**'
-
   build_kokkos:
     runs-on: ubuntu-latest
-    #needs: changes
-    #if: ${{ github.event_name == 'pull_request' || needs.changes.outputs.projects_changed == 'true' }}
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v4
@@ -55,7 +39,6 @@ jobs:
   build_wave_projects:
     runs-on: ubuntu-latest
     needs: [build_kokkos]
-    #if: ${{ github.event_name == 'pull_request' || needs.changes.outputs.projects_changed == 'true' }}
     steps:
       - name: Set up Git repository
         uses: actions/checkout@v4

--- a/courses/01_beginners/main.tex
+++ b/courses/01_beginners/main.tex
@@ -1,7 +1,5 @@
 % !TeX program = xelatex
 
-% test
-
 \documentclass[
     aspectratio=169,
     handout,

--- a/courses/01_beginners/main.tex
+++ b/courses/01_beginners/main.tex
@@ -1,5 +1,7 @@
 % !TeX program = xelatex
 
+% test
+
 \documentclass[
     aspectratio=169,
     handout,


### PR DESCRIPTION
This PR uses the `branch` restriction in favor to the change detection action, for the CI of the entire repository.