### PR TITLE
Fix animation frames ordering in the wave project visualization scripts

### DIFF
--- a/projects/01_wave/openmp/main.cpp
+++ b/projects/01_wave/openmp/main.cpp
@@ -24,7 +24,8 @@ void write_grid(const std::vector<double>& U,
                 unsigned int Ny, 
                 double dx,
                 double dy,
-                unsigned int it);
+                unsigned int it,
+                unsigned int padding);
 
 // __________________________________________________________________________
 //
@@ -154,6 +155,12 @@ int main(int argc, char* argv[]) {
     system("rm -rf diags");
     system("mkdir -p diags");
 
+    // Maximum number of characters for the iteration number
+    const unsigned int iteration_number_padding =
+        number_of_iteration == 0
+            ? 1
+            : static_cast<unsigned int>(std::log10(number_of_iteration)) + 1;
+
     // __________________________________________________________________________
     // Print summary of parameters
 
@@ -218,7 +225,7 @@ int main(int argc, char* argv[]) {
         } 
     }
 
-    write_grid(U, Nx, Ny, dx,dy, 0);
+    write_grid(U, Nx, Ny, dx,dy, 0, iteration_number_padding);
 
 
     // __________________________________________________________________________
@@ -290,7 +297,7 @@ int main(int argc, char* argv[]) {
 
         // write the grid to a file
         if (it % output_period == 0) {
-            write_grid(U, Nx, Ny, dx,dy, it);
+            write_grid(U, Nx, Ny, dx,dy, it, iteration_number_padding);
         }
 
         // Print iteration information in the terminal
@@ -341,11 +348,12 @@ void write_grid(const std::vector<double>& U,
                 unsigned int Ny, 
                 double dx,
                 double dy,
-                unsigned int it) {
+                unsigned int it,
+                unsigned int padding) {
 
     // File name of the form grid_0000.json
     std::stringstream filename("");
-    filename << "diags/grid_" << std::setfill('0') << std::setw(4) << it << ".json";
+    filename << "diags/grid_" << std::setfill('0') << std::setw(padding) << it << ".json";
 
     std::ofstream file(filename.str());
     file <<  "{\n";

--- a/projects/01_wave/python/animate.py
+++ b/projects/01_wave/python/animate.py
@@ -11,6 +11,7 @@ import json
 from matplotlib import *
 from matplotlib.pyplot import *
 import matplotlib.animation as animation
+import re
 
 # ______________________________________________________________________________
 # RCParams - personalize the figure output
@@ -50,7 +51,8 @@ else:
 
 file_list = glob.glob("{}/grid_*.json".format(file_path))
 
-file_list = sorted(file_list)
+iter_number_re = re.compile(r"{}/grid_(\d+).json".format(file_path))
+file_list = sorted(file_list, key=lambda p: int(iter_number_re.match(p).group(1)))
 
 # ______________________________________________________________________________
 # Animation function

--- a/projects/01_wave/python/animate_3d.py
+++ b/projects/01_wave/python/animate_3d.py
@@ -12,6 +12,7 @@ from matplotlib import *
 from matplotlib.pyplot import *
 import matplotlib.animation as animation
 from mpl_toolkits.mplot3d import Axes3D
+import re
 
 # ______________________________________________________________________________
 # RCParams - personalize the figure output
@@ -51,7 +52,8 @@ else:
 
 file_list = glob.glob("{}/grid_*.json".format(file_path))
 
-file_list = sorted(file_list)
+iter_number_re = re.compile(r"{}/grid_(\d+).json".format(file_path))
+file_list = sorted(file_list, key=lambda p: int(iter_number_re.match(p).group(1)))
 
 # ______________________________________________________________________________
 # Animation function

--- a/projects/01_wave/sequential/main.cpp
+++ b/projects/01_wave/sequential/main.cpp
@@ -23,7 +23,8 @@ void write_grid(const std::vector<double>& U,
                 unsigned int Ny, 
                 double dx,
                 double dy,
-                unsigned int it);
+                unsigned int it,
+                unsigned int padding);
 
 // __________________________________________________________________________
 //
@@ -152,6 +153,12 @@ int main(int argc, char* argv[]) {
     system("rm -rf diags");
     system("mkdir -p diags");
 
+    // Maximum number of characters for the iteration number
+    const unsigned int iteration_number_padding =
+        number_of_iteration == 0
+            ? 1
+            : static_cast<unsigned int>(std::log10(number_of_iteration)) + 1;
+
     // __________________________________________________________________________
     // Print summary of parameters
 
@@ -210,7 +217,7 @@ int main(int argc, char* argv[]) {
         }
     } 
 
-    write_grid(U, Nx, Ny, dx,dy, 0);
+    write_grid(U, Nx, Ny, dx,dy, 0, iteration_number_padding);
 
 
     // __________________________________________________________________________
@@ -273,7 +280,7 @@ int main(int argc, char* argv[]) {
 
         // write the grid to a file
         if (it % output_period == 0) {
-            write_grid(U, Nx, Ny, dx,dy, it);
+            write_grid(U, Nx, Ny, dx,dy, it, iteration_number_padding);
         }
 
         // Print iteration information in the terminal
@@ -322,11 +329,12 @@ void write_grid(const std::vector<double>& U,
                 unsigned int Ny, 
                 double dx,
                 double dy,
-                unsigned int it) {
+                unsigned int it,
+                unsigned int padding) {
 
     // File name of the form grid_0000.json
     std::stringstream filename("");
-    filename << "diags/grid_" << std::setfill('0') << std::setw(4) << it << ".json";
+    filename << "diags/grid_" << std::setfill('0') << std::setw(padding) << it << ".json";
 
     std::ofstream file(filename.str());
     file <<  "{\n";

--- a/projects/01_wave/solution/main.cpp
+++ b/projects/01_wave/solution/main.cpp
@@ -22,7 +22,8 @@ void write_grid(const Kokkos::View<double**>::HostMirror& U,
                 unsigned int Ny, 
                 double dx,
                 double dy,
-                unsigned int it);
+                unsigned int it,
+                unsigned int padding);
 
 // __________________________________________________________________________
 //
@@ -152,6 +153,12 @@ int main(int argc, char* argv[]) {
     system("rm -rf diags");
     system("mkdir -p diags");
 
+    // Maximum number of characters for the iteration number
+    const unsigned int iteration_number_padding =
+        number_of_iteration == 0
+            ? 1
+            : static_cast<unsigned int>(std::log10(number_of_iteration)) + 1;
+
     // __________________________________________________________________________
     // Print summary of parameters
 
@@ -227,7 +234,7 @@ int main(int argc, char* argv[]) {
 
     Kokkos::fence();
 
-    write_grid(U_host, Nx, Ny, dx,dy, 0);
+    write_grid(U_host, Nx, Ny, dx,dy, 0, iteration_number_padding);
 
     Kokkos::deep_copy(U, U_host);
     Kokkos::deep_copy(U_prev, U_prev_host);
@@ -319,7 +326,7 @@ int main(int argc, char* argv[]) {
         // write the grid to a file
         if (it % output_period == 0) {
             Kokkos::deep_copy(U_host, U);
-            write_grid(U_host, Nx, Ny, dx,dy, it);
+            write_grid(U_host, Nx, Ny, dx,dy, it, iteration_number_padding);
         }
 
         // Print iteration information in the terminal
@@ -372,11 +379,12 @@ void write_grid(const Kokkos::View<double**>::HostMirror& U,
                 unsigned int Ny, 
                 double dx,
                 double dy,
-                unsigned int it) {
+                unsigned int it,
+                unsigned int padding) {
 
     // File name of the form grid_0000.json
     std::stringstream filename("");
-    filename << "diags/grid_" << std::setfill('0') << std::setw(4) << it << ".json";
+    filename << "diags/grid_" << std::setfill('0') << std::setw(padding) << it << ".json";
 
     std::ofstream file(filename.str());
     file <<  "{\n";


### PR DESCRIPTION
In the wave project, the python animation scripts glob the output files and sort them alphabetically, this works for iterations up to 9999 because the c++ program pads the iteration number in the output filename to 4 digits, but going beyond that messes up the ordering (1000 < 10000 < 1100 when sorted alphabetically).

To fix this we can simply extract the iteration number from the filenames using a regex and sort the files according to this number.