### PR TITLE
Better integration of Kokkos in the project

### DIFF
--- a/cmake/SetUpKokkos.cmake
+++ b/cmake/SetUpKokkos.cmake
@@ -12,13 +12,19 @@ if(NOT CMAKE_BUILD_TYPE)
     )
 endif()
 
+option(
+    CexaKokkosTutorials_KOKKOS_SOURCE_DIR
+    "Path to the local source directory of Kokkos"
+    "${CMAKE_CURRENT_LIST_DIR}/../vendor/kokkos"
+)
+
 # find Kokkos as an already existing target
 if(TARGET Kokkos::kokkos)
     return()
 endif()
 
 # find Kokkos as installed
-find_package(Kokkos CONFIG)
+find_package(Kokkos QUIET)
 if(Kokkos_FOUND)
     message(STATUS "Kokkos provided as installed: ${Kokkos_DIR} (version \"${Kokkos_VERSION}\")")
 
@@ -26,13 +32,6 @@ if(Kokkos_FOUND)
 endif()
 
 # find Kokkos as an existing source directory
-set(
-    CexaKokkosTutorials_KOKKOS_SOURCE_DIR
-    "${CMAKE_CURRENT_SOURCE_DIR}/../../../vendor/kokkos"
-    CACHE
-    PATH
-    "Path to the local source directory of Kokkos"
-)
 if(EXISTS "${CexaKokkosTutorials_KOKKOS_SOURCE_DIR}/CMakeLists.txt")
     message(STATUS "Kokkos provided as a source directory: ${CexaKokkosTutorials_KOKKOS_SOURCE_DIR}")
 
@@ -54,4 +53,3 @@ FetchContent_Declare(
     SOURCE_DIR ${CexaKokkosTutorials_KOKKOS_SOURCE_DIR}
 )
 FetchContent_MakeAvailable(kokkos)
-set(Kokkos_FOUND True)

--- a/cmake/SetUpKokkos.cmake
+++ b/cmake/SetUpKokkos.cmake
@@ -1,3 +1,18 @@
+# Setup Kokkos as either an external dependency, or an inlined dependency. In
+# the former, Kokkos has already been compiled and installed, and its install
+# path is given to CMake with `Kokkos_ROOT` option. In the later, Kokkos
+# sources are either already present as a Git submodule, or they are downloaded
+# by this script using CMake `FetchContent`; in either case Kokkos sources are
+# located in `/vendor/kokkos` and compiled along with the project, which means
+# that Kokkos options must be passed at configuration time. If the option
+# `CMAKE_DISABLE_FIND_PACKAGE_Kokkos` is `ON`, then no installed instance of
+# Kokkos will be used, and only the inline build of Kokkos will take place.
+# Conversely, if the option `CMAKE_REQUIRE_FIND_PACKAGE_Kokkos` is `ON`, then
+# only an installed instance of Kokkos will be used.
+#
+# See
+# https://kokkos.org/kokkos-core-wiki/get-started/integrating-kokkos-into-your-cmake-project.html#supporting-both-external-and-embedded-kokkos
+
 # set CMAKE_BUILD_TYPE if not defined
 if(NOT CMAKE_BUILD_TYPE)
     set(default_build_type "RelWithDebInfo")

--- a/cmake/SetUpKokkos.cmake
+++ b/cmake/SetUpKokkos.cmake
@@ -12,10 +12,12 @@ if(NOT CMAKE_BUILD_TYPE)
     )
 endif()
 
-option(
+set(
     CexaKokkosTutorials_KOKKOS_SOURCE_DIR
-    "Path to the local source directory of Kokkos"
     "${CMAKE_CURRENT_LIST_DIR}/../vendor/kokkos"
+    CACHE
+    PATH
+    "Path to the local source directory of Kokkos"
 )
 
 # find Kokkos as an already existing target

--- a/cmake/SetUpKokkos.cmake
+++ b/cmake/SetUpKokkos.cmake
@@ -51,7 +51,8 @@ include(FetchContent)
 FetchContent_Declare(
     kokkos
     DOWNLOAD_EXTRACT_TIMESTAMP ON
-    URL https://github.com/kokkos/kokkos/releases/download/4.5.01/kokkos-4.5.01.zip
+    URL https://github.com/kokkos/kokkos/releases/download/4.6.01/kokkos-4.6.01.tar.gz
+    URL_HASH SHA256=b9d70e4653b87a06dbb48d63291bf248058c7c7db4bd91979676ad5609bb1a3a
     SOURCE_DIR ${CexaKokkosTutorials_KOKKOS_SOURCE_DIR}
 )
 FetchContent_MakeAvailable(kokkos)

--- a/exercises/01_first_program/README.md
+++ b/exercises/01_first_program/README.md
@@ -6,11 +6,18 @@ The goal is to get familiar with the compiling process.
 ## Step 1: Simple Kokkos program
 
 In `exercise`, open the file `main.cpp`, initialize and finalize Kokkos.
-Do not forget to add the header.
+Do not forget to include the header.
 
 Add a call to the `Kokkos::print_configuration` function to print the configuration of Kokkos.
 
 ## Step 2: Compile the program with the serial backend
+
+Open the `CMakeLists.txt` file and check its content.
+In all this tutorial, Kokkos is included to your build with the `/cmake/SetUpKokkos.cmake` script, either as an external dependency, or as an inlined dependency.
+In the former, Kokkos has already been compiled and installed, and its install path is given to CMake with `Kokkos_ROOT` option.
+In the later, Kokkos sources are either already present as a Git submodule, or they are downloaded by the script using CMake `FetchContent`; in either case Kokkos sources are located in `/vendor/kokkos` and compiled along with the project, which means that Kokkos options must be passed at configuration time.
+If the option `CMAKE_DISABLE_FIND_PACKAGE_Kokkos` is `ON`, then no installed instance of Kokkos will be used, and only the inline build of Kokkos will take place.
+Conversely, if the option `CMAKE_REQUIRE_FIND_PACKAGE_Kokkos` is `ON`, then only an installed instance of Kokkos will be used.
 
 Compile your program using the serial backend.
 You can use the following commands:
@@ -21,6 +28,7 @@ cmake -B build_serial
 cmake --build build_serial
 ```
 
+This would use build Kokkos along with your code.
 If you have already installed Kokkos in exercise 0, then you can use the following commands instead:
 
 ```sh

--- a/exercises/01_first_program/exercise/CMakeLists.txt
+++ b/exercises/01_first_program/exercise/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(01FirstProgramExercise LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(exe01 main.cpp)
 target_link_libraries(exe01 Kokkos::kokkos)

--- a/exercises/01_first_program/solution/CMakeLists.txt
+++ b/exercises/01_first_program/solution/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(01FirstProgramSolution LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(exe01solution main.cpp)
 target_link_libraries(exe01solution Kokkos::kokkos)

--- a/exercises/02_basic_view/exercise/CMakeLists.txt
+++ b/exercises/02_basic_view/exercise/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(02BasicViewExercise LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(exe02 main.cpp)
 target_link_libraries(exe02 Kokkos::kokkos)

--- a/exercises/02_basic_view/solution/CMakeLists.txt
+++ b/exercises/02_basic_view/solution/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(02BasicViewSolution LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(exe02solution main.cpp)
 target_link_libraries(exe02solution Kokkos::kokkos)

--- a/exercises/03_deep_copy/exercise/CMakeLists.txt
+++ b/exercises/03_deep_copy/exercise/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(03DeepCopyExercise LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(exe03 main.cpp)
 target_link_libraries(exe03 Kokkos::kokkos)

--- a/exercises/03_deep_copy/solution/CMakeLists.txt
+++ b/exercises/03_deep_copy/solution/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(03DeepCopySolution LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(exe03solution main.cpp)
 target_link_libraries(exe03solution Kokkos::kokkos)

--- a/exercises/04_parallel_loop/exercise/CMakeLists.txt
+++ b/exercises/04_parallel_loop/exercise/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(04ParallelLoopExercise LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(exe04 main.cpp)
 target_link_libraries(exe04 Kokkos::kokkos)

--- a/exercises/04_parallel_loop/solution/CMakeLists.txt
+++ b/exercises/04_parallel_loop/solution/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(04ParallelLoopSolution LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(exe04solution main.cpp)
 target_link_libraries(exe04solution Kokkos::kokkos)

--- a/exercises/05_parallel_reduce/exercise/CMakeLists.txt
+++ b/exercises/05_parallel_reduce/exercise/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(05ParallelReduceExercise LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(exe05 main.cpp)
 target_link_libraries(exe05 Kokkos::kokkos)

--- a/exercises/05_parallel_reduce/solution/CMakeLists.txt
+++ b/exercises/05_parallel_reduce/solution/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(05ParallelReduceSolution LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(exe05solution main.cpp)
 target_link_libraries(exe05solution Kokkos::kokkos)

--- a/projects/01_wave/exercise/CMakeLists.txt
+++ b/projects/01_wave/exercise/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(01WaveExercise LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(proj01 main.cpp)
 target_link_libraries(proj01 Kokkos::kokkos)

--- a/projects/01_wave/solution/CMakeLists.txt
+++ b/projects/01_wave/solution/CMakeLists.txt
@@ -2,9 +2,7 @@ cmake_minimum_required (VERSION 3.21)
 
 project(01WaveSolution LANGUAGES CXX)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/../../../cmake/modules")
-
-find_package(Kokkos REQUIRED)
+include(../../../cmake/SetUpKokkos.cmake)
 
 add_executable(proj01solution main.cpp)
 target_link_libraries(proj01solution Kokkos::kokkos)


### PR DESCRIPTION
- Use a clearly identified script to get Kokkos, instead of the homemade `FindKokkos.cmake`;
- Update Kokkos to the latest version.

Fixes #31.