### PR TITLE
Mention the Kokkos_ARCH_NATIVE flag in the SIMD section

### DIFF
--- a/courses/02_intermediate/main.tex
+++ b/courses/02_intermediate/main.tex
@@ -523,8 +523,7 @@
     \begin{itemize}
         \item A \texttt{Kokkos::Experimental::simd} type wrapping platform specific vectors
         \item A corresponding \texttt{Kokkos::Experimental::simd\_mask} type
-        \item Operators for doing basic operations on these types (arithmetic, bitwise, shift, comparison, ...)
-        \item No need to remember complicated intrinsics names
+        \item Operators for doing basic operations on these types (arithmetic, bitwise, shift, comparison, ...), which allows for more readable code
           \begin{minted}{C++}
               Kokkos::Experimental::simd<int> a, b, c;
               a *= (a + b) & (c << 2);
@@ -532,6 +531,9 @@
         \item Auxiliary functions (load, store, etc)
         \item Math functions working on SIMD types
     \end{itemize}
+    \begin{block}{Compiling Kokkos for vectorization}
+        In order to enable vectorization, you should specify a CPU architecture flag with cmake, or use \texttt{-DKokkos\_ARCH\_NATIVE=ON} to optimize for the CPU you are compiling on
+    \end{block}
 \end{frame}
 
 \begin{frame}[fragile]{Kokkos SIMD}


### PR DESCRIPTION
I added a block mentioning that vectorization requires a CPU arch flag to be passed when configuring kokkos, I also merged 2 of the bullet points, the slide looks like this
<img width="1176" height="666" alt="image" src="https://github.com/user-attachments/assets/ffdef4b4-d619-4c5a-bb85-c623d55863b0" />
